### PR TITLE
fix: fix typing in theme overriding

### DIFF
--- a/src/SqlHighlighter.ts
+++ b/src/SqlHighlighter.ts
@@ -2,9 +2,11 @@ import c from 'ansi-colors';
 import { Token, Tokenizer } from './Tokenizer';
 import { TokenType, HighlightSubject, TOKEN_TYPE_TO_HIGHLIGHT } from './enums';
 
+type Theme = { [key in HighlightSubject]?: c.StyleFunction };
+
 export class SqlHighlighter {
 
-  static readonly DEFAULT_THEME = {
+  static readonly DEFAULT_THEME: Theme = {
     [HighlightSubject.QUOTE]: c.yellow,
     [HighlightSubject.BACKTICK_QUOTE]: c.yellow,
     [HighlightSubject.RESERVED]: c.white.bold,
@@ -16,11 +18,13 @@ export class SqlHighlighter {
     [HighlightSubject.FUNCTIONS]: c.green.bold,
     [HighlightSubject.BUILT_IN]: c.cyan,
     [HighlightSubject.LITERAL]: c.cyan,
+    [HighlightSubject.WHITESPACE]: undefined,
+    [HighlightSubject.ERROR]: undefined,
   };
 
   private readonly tokenizer = new Tokenizer();
 
-  constructor(private readonly theme: { [K in keyof typeof HighlightSubject]?: string } = {}) {
+  constructor(private readonly theme: Theme = {}) {
     this.theme = { ...SqlHighlighter.DEFAULT_THEME, ...this.theme };
   }
 
@@ -50,11 +54,15 @@ export class SqlHighlighter {
   }
 
   private colorize(type: TokenType, value: string): string {
-    if (!TOKEN_TYPE_TO_HIGHLIGHT[type] || !this.theme[TOKEN_TYPE_TO_HIGHLIGHT[type]]) {
+    const subject = TOKEN_TYPE_TO_HIGHLIGHT[type];
+    if (!subject) {
       return value;
     }
-
-    return this.theme[TOKEN_TYPE_TO_HIGHLIGHT[type]](value);
+    const fct = this.theme[subject];
+    if (!fct) {
+      return value;
+    }
+    return fct(value);
   }
 
 }

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -28,9 +28,11 @@ export enum HighlightSubject {
   FUNCTIONS = 'functions',
   LITERAL = 'literal',
   BUILT_IN = 'builtIn',
+  WHITESPACE = 'whitespace',
+  ERROR = 'error',
 }
 
-export const TOKEN_TYPE_TO_HIGHLIGHT = {
+export const TOKEN_TYPE_TO_HIGHLIGHT: Record<TokenType, HighlightSubject | undefined> = {
   [TokenType.BOUNDARY]: HighlightSubject.BOUNDARY,
   [TokenType.WORD]: HighlightSubject.WORD,
   [TokenType.BACKTICK_QUOTE]: HighlightSubject.BACKTICK_QUOTE,
@@ -44,4 +46,6 @@ export const TOKEN_TYPE_TO_HIGHLIGHT = {
   [TokenType.BLOCK_COMMENT]: HighlightSubject.COMMENT,
   [TokenType.LITERAL]: HighlightSubject.LITERAL,
   [TokenType.BUILT_IN]: HighlightSubject.BUILT_IN,
+  [TokenType.WHITESPACE]: HighlightSubject.WHITESPACE,
+  [TokenType.ERROR]: HighlightSubject.ERROR,
 };


### PR DESCRIPTION
This: `{ [K in keyof typeof HighlightSubject]?: string } `
- gives a type with UPPER CASE keys, but the default theme and how it's resolved via `TOKEN_TYPE_TO_HIGHLIGHT` expects the values, i.e. lower case
- string is wrong type as a `StyleFunction` is expected and then called

I.e. the types suggest this
  `new SqlHighlighter({ RESERVED: 'red' })` but this has no effect. To get it to work w/o this fix:
  `new SqlHighlighter({ reserved: c.red.bold } as any)`